### PR TITLE
Updated for httpd 0.13.0 and null safety

### DIFF
--- a/example/vexilla_client_example.dart
+++ b/example/vexilla_client_example.dart
@@ -10,7 +10,7 @@ void main() async {
 
   client.setFlags(flags);
 
-  if (client.should('FEATURE_NAME')) {
+  if (client.should('FEATURE_NAME')!) {
     print('User should be able to use a feature.');
   }
   ;

--- a/lib/src/vexilla_client_base.dart
+++ b/lib/src/vexilla_client_base.dart
@@ -8,21 +8,21 @@ const vexillaFeatureTypeGradual = 'gradual';
 class VexillaClient {
   final String _baseUrl, _environment, _customInstanceHash;
 
-  Map _flags;
+  Map? _flags;
 
   VexillaClient(this._environment, this._baseUrl, this._customInstanceHash);
 
-  Future<Map> fetchFlags(String fileName) async {
+  Future<Map?> fetchFlags(String fileName) async {
     var response = await http.get(Uri.parse('$_baseUrl/$fileName'));
     return jsonDecode(response.body);
   }
 
-  void setFlags(Map flags) {
+  void setFlags(Map? flags) {
     _flags = flags;
   }
 
-  bool should(String featureName) {
-    var feature = _flags['environments'][_environment]['untagged'][featureName];
+  bool? should(String featureName) {
+    var feature = _flags!['environments'][_environment]['untagged'][featureName];
 
     if (feature['type'] == vexillaFeatureTypeToggle) {
       return feature['value'];

--- a/lib/src/vexilla_client_base.dart
+++ b/lib/src/vexilla_client_base.dart
@@ -13,7 +13,7 @@ class VexillaClient {
   VexillaClient(this._environment, this._baseUrl, this._customInstanceHash);
 
   Future<Map> fetchFlags(String fileName) async {
-    var response = await http.get('${_baseUrl}/${fileName}');
+    var response = await http.get(Uri.parse('$_baseUrl/$fileName'));
     return jsonDecode(response.body);
   }
 

--- a/lib/src/vexilla_client_base.dart
+++ b/lib/src/vexilla_client_base.dart
@@ -8,21 +8,21 @@ const vexillaFeatureTypeGradual = 'gradual';
 class VexillaClient {
   final String _baseUrl, _environment, _customInstanceHash;
 
-  Map? _flags;
+  Map _flags;
 
   VexillaClient(this._environment, this._baseUrl, this._customInstanceHash);
 
-  Future<Map?> fetchFlags(String fileName) async {
+  Future<Map> fetchFlags(String fileName) async {
     var response = await http.get(Uri.parse('$_baseUrl/$fileName'));
     return jsonDecode(response.body);
   }
 
-  void setFlags(Map? flags) {
+  void setFlags(Map flags) {
     _flags = flags;
   }
 
-  bool? should(String featureName) {
-    var feature = _flags!['environments'][_environment]['untagged'][featureName];
+  bool should(String featureName) {
+    var feature = _flags['environments'][_environment]['untagged'][featureName];
 
     if (feature['type'] == vexillaFeatureTypeToggle) {
       return feature['value'];

--- a/lib/src/vexilla_client_base.dart
+++ b/lib/src/vexilla_client_base.dart
@@ -8,21 +8,22 @@ const vexillaFeatureTypeGradual = 'gradual';
 class VexillaClient {
   final String _baseUrl, _environment, _customInstanceHash;
 
-  Map _flags;
+  Map? _flags;
 
   VexillaClient(this._environment, this._baseUrl, this._customInstanceHash);
 
-  Future<Map> fetchFlags(String fileName) async {
+  Future<Map?> fetchFlags(String fileName) async {
     var response = await http.get(Uri.parse('$_baseUrl/$fileName'));
     return jsonDecode(response.body);
   }
 
-  void setFlags(Map flags) {
+  void setFlags(Map? flags) {
     _flags = flags;
   }
 
-  bool should(String featureName) {
-    var feature = _flags['environments'][_environment]['untagged'][featureName];
+  bool? should(String featureName) {
+    var feature =
+        _flags!['environments'][_environment]['untagged'][featureName];
 
     if (feature['type'] == vexillaFeatureTypeToggle) {
       return feature['value'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
-  http: ^0.12.0
+  http: ^0.13.0
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  http: '>=0.12.0'
+  http: ^0.13.0
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: vexilla_client
 description: A Dart client for the Vexilla Feature Flag System.
-version: 0.1.0
+version: 0.0.4
 homepage: https://vexilla.github.io
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
-  http: ^0.13.0
+  http: '>=0.12.0'
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vexilla_client
 description: A Dart client for the Vexilla Feature Flag System.
-version: 0.0.2
+version: 0.0.3
 homepage: https://vexilla.github.io
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 homepage: https://vexilla.github.io
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   http: ^0.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: vexilla_client
 description: A Dart client for the Vexilla Feature Flag System.
-version: 0.0.4
+version: 0.1.0
 homepage: https://vexilla.github.io
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   http: '>=0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vexilla_client
 description: A Dart client for the Vexilla Feature Flag System.
-version: 0.0.3
+version: 0.1.0
 homepage: https://vexilla.github.io
 
 environment:


### PR DESCRIPTION
Migrated it for null safety https://dart.dev/null-safety/unsound-null-safety#sound-and-unsound-null-safety
and updated the httpd dependency to 0.13.0 due to personal needs

maybe it could be relevant for others

let me know if I need to change anything or just close it if you don't think this needs to be merged.

Thank you for the tool.